### PR TITLE
Flex fuel boost control

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1111,7 +1111,7 @@ page = 10
 
       flexBoostBins       = array,  U08,      33, [6], "%",    1.0,       0.0,   0.0,     250.0,    0
       ; The boost range is obviously arbitrary since int16_t has ~32k in both directions
-      flexBoostAdj        = array,  S16,      39, [6], "kPa",  1.0,       0.0,   -500.0,  500.0,    0
+      flexBoostBias        = array,  S16,      39, [6], "kPa",  1.0,       0.0,   -500.0,  500.0,    0
       flexFuelBins        = array,  U08,      51, [6], "%",    1.0,       0.0,   0.0,     250.0,    0
       flexFuelBias         = array,  U08,      57, [6], "%",    1.0,       0.0,   0.0,     200.0,    0
       flexAdvBins         = array,  U08,      63, [6], "%",    1.0,       0.0,   0.0,     250.0,    0
@@ -1463,13 +1463,19 @@ page = 15
 ;-------------------------------------------------------------------------------
 ;Secondary corrections values
 ;-------------------------------------------------------------------------------
-      asePct2                = array,  U08,       106, [4],    "%",        5.0,       0.0,  0,    1175,       0
-      wueRates2              = array,  U08,       110, [10],   "%",        5.0,      0.0,  0.0,   1225,       0
-      crankingEnrichValues2  = array,  U08,       120, [4],    "%",        10.0,      0.0,  0,    2550,       0 ; Values for the secondary cranking enrichment curve
-      primePulse2            = array,  U08,       124, [4],    "ms",       0.5,       0.0,  0.0,  127.5,      1
+      asePct2                = array,  U08,       106,  [4],    "%",        5.0,       0.0,    0,    1175,    0
+      wueRates2              = array,  U08,       110, [10],    "%",        5.0,       0.0,  0.0,    1225,    0
+      crankingEnrichValues2  = array,  U08,       120,  [4],    "%",        10.0,      0.0,    0,    2550,    0 ; Values for the secondary cranking enrichment curve
+      primePulse2            = array,  U08,       124,  [4],    "ms",       0.5,       0.0,  0.0,   127.5,    1
+      Unused15_128_175       = array,  U08,       128, [47],    "%",        1.0,       0.0,  0.0,     255,    0
+
+;-------------------------------------------------------------------------------
+      boostTable2            = array,  U08,       176, [8x8], { bitStringValue( boostTableLabels, boostType ) },        2.0,        0.0,     0,    {boostTableLimit},      0
+      rpmBinsBoost2           = array,  U08,      240, [  8],                                             "RPM",      100.0,        0.0,   100,                25500,      0
+      tpsBinsBoost2           = array,  U08,      248, [  8],                                             "TPS",        0.5,        0.0,   0.0,                127.0,      1
 ;-------------------------------------------------------------------------------
 
-      Unused15_128_255               = array,   U08,   128,   [127],   "%", 1.0,   0.0,     0.0,      255,    0
+      
 
 ;-------------------------------------------------------------------------------
 
@@ -2018,6 +2024,7 @@ menuDialog = main
         subMenu = dwell_tblMap    "Dwell Map", { useDwellMap }
         subMenu = stagingMap      "Fuel Staging", { stagingMode == 0 }
         subMenu = boostMap,       "Boost Duty / Target", { boostEnabled }
+        subMenu = boostMap2,      "Secondary Boost Duty / Target", { boostEnabled }
         subMenu = boostDutyLookup "Boost Base Duty Closed Loop", { boostType == 1 }
         subMenu = vvtMap          "VVT Control", { vvtEnabled }
         subMenu = vvt2Map         "VVT 2 Control", { vvtEnabled && vvt2Enabled }
@@ -2159,7 +2166,7 @@ menuDialog = main
   flexFreqHigh      = "The frequency of the sensor at 100% ethanol (150Hz for standard GM/Continental sensor)"
   flexFuelBias       = "Percentage bias toward second fuel table values. 0% bias uses VE table only, 100% bias uses second fuel table only, 50% bias will compute a value halfway between VE table and second fuel table value."
   flexAdvBias        = "Percentage bias toward second spark table values. 0% bias uses primary spark table only, 100% bias uses second spark table only, 50% bias will compute a value halfway between primary and second spark table value."
-  flexBoostAdj      = "Adjustment, in kPa, to the boost target for the current ethanol %. Negative values are allowed to lower boost at lower ethanol % if necessary."
+  flexBoostBias      = "Percentage bias toward second boost table values. Works the same for both open and closed loop. Works the same as flex fuel and spark."
 
   n2o_arming_pin    = "Pin that the nitrous arming/engagement switch is on."
   n2o_pin_polarity  = "Whether Nitrous is active (Armed) when the pin is LOW or HIGH. If LOW is selected, the internal pullup will be used."
@@ -3006,9 +3013,15 @@ menuDialog = main
         field = "In closed loop mode, the values in this table are boost targets in kPa", {}, {}, { boostType == 1 }
         panel = boostTbl
 
+    dialog = boostDCTarget2, "Secondary Boost table"
+        field = "In open loop mode, the values in this table are duty cycle %", {}, {}, { boostType == 0 }
+        field = "In closed loop mode, the values in this table are boost targets in kPa", {}, {}, { boostType == 1 }
+        panel = boostTbl2
+
     dialog = boostLoad, ""
         field = "Mode",                     boostType
         panel = boostDCTarget
+        panel = boostDCTarget2, { flexEnabled }
         panel = boostBaseDC, { boostType == 1 }
 
       dialog = coolantProtection, "Coolant Based Rev Limit"
@@ -4727,12 +4740,12 @@ cmdVSSratio6 =      "E\x99\x06"
           yBins           = flexAdvBias
           size            = 400, 200
 
-        curve = flex_boost_curve, "Flex Boost Adjustments"
-          columnLabel     = "Ethanol", "Boost"
+        curve = flex_boost_curve, "Flex Boost Table 2 Bias"
+          columnLabel     = "Ethanol", "Bias"
           xAxis           = 0, 100, 10
-          yAxis           = -100, 200, 5
+          yAxis           = 0, 200, 5
           xBins           = flexBoostBins, flex
-          yBins           = flexBoostAdj
+          yBins           = flexBoostBias
           size            = 400, 200
 
 ;Knock sensor windows
@@ -4887,6 +4900,13 @@ cmdVSSratio6 =      "E\x99\x06"
       xBins = rpmBinsBoost, rpm
       yBins = tpsBinsBoost, throttle
       zBins = boostTable
+      gridHeight  = 3.0
+      upDownLabel = "HIGHER", "LOWER"
+
+    table = boostTbl2,    boostMap2,  "Boost Duty / Target", 7
+      xBins = rpmBinsBoost2, rpm
+      yBins = tpsBinsBoost2, throttle
+      zBins = boostTable2
       gridHeight  = 3.0
       upDownLabel = "HIGHER", "LOWER"
 

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -466,6 +466,7 @@ extern struct table3d16RpmLoad ignitionTable2; //16x16 ignition map
 extern struct table3d16RpmLoad afrTable; //16x16 afr target map
 extern struct table3d8RpmLoad stagingTable; //8x8 fuel staging table
 extern struct table3d8RpmLoad boostTable; //8x8 boost map
+extern struct table3d8RpmLoad boostTable2; //8x8 boost map
 extern struct table3d8RpmLoad boostTableLookupDuty; //8x8 boost map
 extern struct table3d8RpmLoad vvtTable; //8x8 vvt map
 extern struct table3d8RpmLoad vvt2Table; //8x8 vvt map
@@ -1228,7 +1229,7 @@ struct config10 {
   byte lnchCtrlTPS; //Byte 32
 
   uint8_t flexBoostBins[6]; //Bytes 33-38
-  int16_t flexBoostAdj[6];  //kPa to be added to the boost target @ current ethanol (negative values allowed). Bytes 39-50
+  int16_t flexBoostBias[6];  //kPa to be added to the boost target @ current ethanol (negative values allowed). Bytes 39-50
   uint8_t flexFuelBins[6]; //Bytes 51-56
   uint8_t flexFuelBias[6];   //Fuel % @ current ethanol (typically 100% @ 0%, 163% @ 100%). Bytes 57-62
   uint8_t flexAdvBins[6]; //Bytes 63-68
@@ -1496,8 +1497,10 @@ struct config15 {
   byte crankingEnrichValues2[4];
   byte primePulse2[4]; //Priming pulsewidth values (mS, copied to @ref PrimingPulseTable2)
 
-  //Bytes 128-255
-  byte Unused15_128_255[127];
+  //Bytes 128-206
+  byte Unused15_128_175[47];
+
+  //*Boost table 2 occupies bytes 176-255*
   
 
 #if defined(CORE_AVR)

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -14,6 +14,7 @@ struct table3d16RpmLoad ignitionTable2; ///< 16x16 ignition map
 struct table3d16RpmLoad afrTable; ///< 16x16 afr target map
 struct table3d8RpmLoad stagingTable; ///< 8x8 fuel staging table
 struct table3d8RpmLoad boostTable; ///< 8x8 boost map
+struct table3d8RpmLoad boostTable2; ///< 8x8 boost map
 struct table3d8RpmLoad boostTableLookupDuty; ///< 8x8 boost map lookup table
 struct table3d8RpmLoad vvtTable; ///< 8x8 vvt map
 struct table3d8RpmLoad vvt2Table; ///< 8x8 vvt2 map

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -241,7 +241,7 @@ void initialiseAll(void)
     flexBoostTable.valueSize = SIZE_INT;
     flexBoostTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins (NOTE THIS IS DIFFERENT TO THE VALUES!!)
     flexBoostTable.xSize = 6;
-    flexBoostTable.values = configPage10.flexBoostAdj;
+    flexBoostTable.values = configPage10.flexBoostBias;
     flexBoostTable.axisX = configPage10.flexBoostBins;
     fuelTempTable.valueSize = SIZE_BYTE;
     fuelTempTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins

--- a/speeduino/storage.cpp
+++ b/speeduino/storage.cpp
@@ -317,6 +317,13 @@ void writeConfig(uint8_t pageNum)
       | Config page 15 (See storage.h for data layout)
       -----------------------------------------------------*/
       result = write_range((byte *)&configPage15, (byte *)&configPage15+sizeof(configPage15), result.changeWriteAddress(EEPROM_CONFIG15_START));
+
+      /*---------------------------------------------------
+      | Boost table 2 (See storage.h for data layout) - Page 15
+      | 8x8 table itself + the 8 values along each of the axes
+      -----------------------------------------------------*/
+      result = writeTable(&boostTable2, decltype(boostTable2)::type_key, result.changeWriteAddress(EEPROM_CONFIG15_MAP2));
+
       break;
 
     default:

--- a/speeduino/storage.h
+++ b/speeduino/storage.h
@@ -184,6 +184,7 @@ extern uint32_t deferEEPROMWritesUntil;
 //Page 15 added after OUT OF ORDER page 8
 #define EEPROM_CONFIG15_MAP   3199
 #define EEPROM_CONFIG15_START 3281
+#define EEPROM_CONFIG15_MAP2  3375
 #define EEPROM_CONFIG15_END   3457
 
 

--- a/speeduino/updates.ino
+++ b/speeduino/updates.ino
@@ -110,7 +110,7 @@ void doUpdates(void)
     //Convert whatever flex fuel settings are there into the new tables
 
     configPage10.flexBoostBins[0] = 0;
-    configPage10.flexBoostAdj[0]  = (int8_t)configPage2.aeColdPct;
+    configPage10.flexBoostBias[0]  = (int8_t)configPage2.aeColdPct;
 
     configPage10.flexFuelBins[0] = 0;
     configPage10.flexFuelBias[0]  = configPage2.idleUpPin;
@@ -126,7 +126,7 @@ void doUpdates(void)
       configPage10.flexAdvBins[x] = pct;
 
       int16_t boostAdder = (((configPage2.aeColdTaperMin - (int8_t)configPage2.aeColdPct) * pct) / 100) + (int8_t)configPage2.aeColdPct;
-      configPage10.flexBoostAdj[x] = boostAdder;
+      configPage10.flexBoostBias[x] = boostAdder;
 
       //uint8_t fuelAdder = (((configPage2.idleUpAdder - configPage2.idleUpPin) * pct) / 100) + configPage2.idleUpPin;
       configPage10.flexFuelBias[x] = pct; // = fuelAdder; <-- Changed to pct for new flex system


### PR DESCRIPTION
Switched boost control to the dual table/biasedAverage system. Old system was previously just a boost target adder for closed loop only. Users can now configure a second boost table to:

- adjust closed loop flex boost targets across whole 8x8 map 
- set open loop flex duty cycles across whole 8x8 map
- set the bias between the two boost tables based on ETH % 