### PR TITLE
Idle battery pwm correction

### DIFF
--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1472,16 +1472,16 @@ page = 15
       CLTdisableBoostControl = bits,   U08,    134,[1:1],   "Off",      "On"
       IATdisableBoostControl = bits,   U08,    134,[2:2],   "Off",      "On"
       iacPWMfanUp            = bits,   U08,    134,[3:5],   "0", "1", "2", "3", "4", "5", "6", "7"
-      unused15_134_6         = bits,   U08,    134,[6:6],   "Off",      "On"
+      boostDCiatAdjEnable    = bits,   U08,    134,[6:6],   "Off",      "On"
       unused15_134_7         = bits,   U08,    134,[7:7],   "Off",      "On"
       flexBoostLimitAdds     = array,  U08,    135,  [6],   "kPa",       1.0,       0.0,  0.0,     255,    0
 
 #if CELSIUS
-      CLTdisableBoostControlTemp = scalar, U08, 141,          "C",       1.0,       0.0,    0,     255,    0
-      IATdisableBoostControlTemp = scalar, U08, 142,          "C",       1.0,       0.0,    0,     255,    0
+      CLTdisableBoostControlTemp = scalar, U08, 141,          "C",       1.0,     -40,    -40,     215,    0
+      IATdisableBoostControlTemp = scalar, U08, 142,          "C",       1.0,     -40,    -40,     215,    0
 #else
-      CLTdisableBoostControlTemp = scalar, U08, 141,          "F",       1.0,       0.0,    0,     255,    0
-      IATdisableBoostControlTemp = scalar, U08, 142,          "F",       1.0,       0.0,    0,     255,    0
+      CLTdisableBoostControlTemp = scalar, U08, 141,          "F",       1.8,  -22.23,    -40,     419,    0
+      IATdisableBoostControlTemp = scalar, U08, 142,          "F",       1.8,  -22.23,    -40,     419,    0
 #endif
 
       taeRates2              = array,  U08,    143,  [4],     "%",       1.0,       0.0,  0.00,    255.0,  0
@@ -1490,7 +1490,13 @@ page = 15
       iacBattRates           = array,  U08,    152,  [4],     "%",        1,          0,   -24,     24,    0 ;Values for iac duty vs voltage
       boostAuthPlus          = scalar, U08,    156,           "%",       1.0,         0,     0,    100,    0
       boostAuthMinus         = scalar, U08,    157,           "%",       1.0,         0,     0,    100,    0
-      Unused15_156_175       = array,  U08,    158, [18],     "%",       1.0,        0.0,  0.0,    255,    0
+      boostDCiatAdj          = array,  S08,    158,  [4],     "%",       1.0,       0.0,  -100,    100,    0
+#if CELSIUS
+      boostDCiatBins         = array,  U08,    162,  [4],     "C",       1.0,       -40,   -40,    215,    0
+#else
+      boostDCiatBins         = array, U08,     162,  [4],     "F",       1.8,    -22.23,   -40,    419,    0
+#endif
+      Unused15_166_175       = array,  U08,    166, [10],     "%",       1.0,        0.0,  0.0,    255,    0
 
 ;-------------------------------------------------------------------------------
       boostTable2            = array,  U08,    176, [8x8], { bitStringValue( boostTableLabels, boostType ) },        2.0,        0.0,     0,    {boostTableLimit},      0
@@ -3050,6 +3056,11 @@ menuDialog = main
     dialog = boostBaseDC, "Closed loop initial duty"
         field = "Base duty cycle to be used for a given boost target", {}, { boostType == 2 }
         panel = boostDCLupTbl,              { boostEnabled && boostType == 1  }
+
+    dialog = boostDCvsIat, "IAT-based duty cycle adjustments"
+        field = "Enable IAT-based DC adjustments",  boostDCiatAdjEnable
+        field = "Duty cycle % added to open loop DC or closed loop base DC", { boostDCiatAdjEnable }
+        panel = boostDCiatAdj_curve,              { boostDCiatAdjEnable }
     
     dialog = boostDCTarget, "Primary Boost table"
         field = "In open loop mode, the values in this table are duty cycle %", {}, {}, { boostType == 0 }
@@ -3066,6 +3077,7 @@ menuDialog = main
         panel = boostDCTarget
         panel = boostDCTarget2, { flexEnabled }
         panel = boostBaseDC, { boostType == 1 }
+        panel = boostDCvsIat
 
       dialog = coolantProtection, "Coolant Based Rev Limit"
         panel = coolant_prot_curve, { hardRevMode == 2 }
@@ -4541,6 +4553,7 @@ cmdVSSratio6 =      "E\x99\x06"
             xBins = taeBins, TPSdot
             yBins = taeRates
 
+
       curve = time_accel_tpsdot_curve2, "TPS based AE No. 2"
             columnLabel = "TPSdot", "Added"
             xAxis = 0, 1200, 6
@@ -4915,6 +4928,14 @@ cmdVSSratio6 =      "E\x99\x06"
           yBins           = wmiAdvAdj
           size            = 400, 200
 
+        curve = boostDCiatAdj_curve, "Boost DC vs. IAT"
+          columnLabel     = "IAT", "DC % (+/-)"
+          xAxis           = 0, 140, 4
+          yAxis           = -10, 10, 4
+          xBins           = boostDCiatBins, iat
+          yBins           = boostDCiatAdj
+          size            = 400, 200
+
 
 [TableEditor]
    ;       table_id,    map3d_id,    "title",      page
@@ -5000,6 +5021,8 @@ cmdVSSratio6 =      "E\x99\x06"
       zBins = boostTableDutyLookup
       gridHeight  = 3.0
       upDownLabel = "HIGHER", "LOWER"      
+
+    
 
 
     table = vvtTbl,    vvtMap,    "VVT control Table", 7

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1488,7 +1488,9 @@ page = 15
 
       taeRates2              = array,  U08,    143,  [4],     "%",       1.0,       0.0,  0.00,    255.0,  0
       aeColdPct2             = scalar, U08,    147,           "%",       1.0,         0,   100,    255,    0 ;AE cold adjustment %
-      Unused15_148_175       = array,  U08,    148, [28],     "%",       1.0,        0.0,  0.0,    255,    0
+      iacBattCorrectionBins  = array,  U08,    148,  [4],     "V",       0.1,         0,     6,     24,    1 ; Bins for the battery reference voltage
+      iacBattRates           = array,  U08,    152,  [4],     "%",        1,          0,   -24,     24,    0 ;Values for iac duty vs voltage
+      Unused15_156_175       = array,  U08,    156, [20],     "%",       1.0,        0.0,  0.0,    255,    0
 
 ;-------------------------------------------------------------------------------
       boostTable2            = array,  U08,    176, [8x8], { bitStringValue( boostTableLabels, boostType ) },        2.0,        0.0,     0,    {boostTableLimit},      0
@@ -1974,6 +1976,7 @@ menuDialog = main
         subMenu = idleSettings,         "Idle Control"
         subMenu = iacClosedLoop_curve,  "Idle - RPM targets", 7, { iacAlgorithm == 3 || iacAlgorithm == 5 || iacAlgorithm == 6 || iacAlgorithm == 7 || idleAdvEnabled >= 1 }
         subMenu = iacPwm_curve,         "Idle - PWM Duty Cycle", 7, { iacAlgorithm == 2 || iacAlgorithm == 6}
+        subMenu = iacPwmBattCorrection_curve, "Idle - PWM Batt Correction", 7, { iacAlgorithm == 2 || iacAlgorithm == 6}
         subMenu = iacPwmCrank_curve,    "Idle - PWM Cranking Duty Cycle", 7, { iacAlgorithm == 2 || iacAlgorithm == 3 || iacAlgorithm == 6}
         subMenu = iacStep_curve,        "Idle - Stepper Motor", 7, { iacAlgorithm == 4 || iacAlgorithm == 7 }
         subMenu = iacStepCrank_curve,   "Idle - Stepper Motor Cranking", 7, { iacAlgorithm == 4 || iacAlgorithm == 5 || iacAlgorithm == 7 }
@@ -4646,6 +4649,13 @@ cmdVSSratio6 =      "E\x99\x06"
             yAxis = 0, 100, 4
             xBins = iacBins, coolant
             yBins = iacOLPWMVal
+
+        curve = iacPwmBattCorrection_curve, "IAC PWM Duty Battery Correction"
+            columnLabel = "Battery V", "+/- Valve Duty"
+            xAxis =   7, 18, 4
+            yAxis = -10, 10, 4
+            xBins = iacBattCorrectionBins, batteryVoltage 
+            yBins = iacBattRates
 
         ; Cranking duty table for PWM valves
         curve = iacPwmCrank_curve, "IAC PWM Cranking Duty"

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1488,7 +1488,9 @@ page = 15
       aeColdPct2             = scalar, U08,    147,           "%",       1.0,         0,   100,    255,    0 ;AE cold adjustment %
       iacBattCorrectionBins  = array,  U08,    148,  [4],     "V",       0.1,         0,     6,     24,    1 ; Bins for the battery reference voltage
       iacBattRates           = array,  U08,    152,  [4],     "%",        1,          0,   -24,     24,    0 ;Values for iac duty vs voltage
-      Unused15_156_175       = array,  U08,    156, [20],     "%",       1.0,        0.0,  0.0,    255,    0
+      boostAuthPlus          = scalar, U08,    156,           "%",       1.0,         0,     0,    100,    0
+      boostAuthMinus         = scalar, U08,    157,           "%",       1.0,         0,     0,    100,    0
+      Unused15_156_175       = array,  U08,    158, [18],     "%",       1.0,        0.0,  0.0,    255,    0
 
 ;-------------------------------------------------------------------------------
       boostTable2            = array,  U08,    176, [8x8], { bitStringValue( boostTableLabels, boostType ) },        2.0,        0.0,     0,    {boostTableLimit},      0
@@ -2383,6 +2385,8 @@ menuDialog = main
   FILTER_FLEX     = "Higher values provide more filtering, but slower Eth% and fuel temp response. Recommended value: 75"
 
   boostIntv       = "The closed loop control interval will run every this many ms. Generally values between 50% and 100% of the valve frequency work best"
+  boostAuthPlus   = "Maximum % duty cycle added to initial duty by closed loop algo."
+  boostAuthMinus  = "Maximum % duty cycle subtracted from initial duty by closed loop algo. Enter a positive number."
   boostByGearEnabled = "Open loop -> Constant limit in Duty cycle %\nClosed Loop -> Constant limit in kPa\nIn both cases the multiplied option simply takes a percentage of the values in the boost table"
   vvtMode         = "Selects method of VVT control.\nOn/Off = No PWM control and output is only on or off.\nOpen Loop = PWM control where duty is taken directly from VVT table.\nClosed Loop = PWM control where VVT table is Cam angle target map and output duty is PID controlled."
   vvt2Enabled     = "Secondary VVT output. Uses same frequency and control algorithm as primary VVT output."
@@ -3330,6 +3334,8 @@ menuDialog = main
         field = "P",                                boostKP,       { boostEnabled && boostMode && boostType == 1 }
         field = "I",                                boostKI,       { boostEnabled && boostMode && boostType == 1 }
         field = "D",                                boostKD,       { boostEnabled && boostMode && boostType == 1 }
+        field = "PID Control Auth +",               boostAuthPlus, { boostEnabled && boostMode && boostType == 1 }
+        field = "PID Control Auth -",               boostAuthMinus, { boostEnabled && boostMode && boostType == 1 }
 
     dialog = vvt2, "Second VVT output"
         field = "VVT2 Control Enabled",    vvt2Enabled

--- a/reference/speeduino.ini
+++ b/reference/speeduino.ini
@@ -1471,9 +1471,7 @@ page = 15
       CLTboostCutEnabled     = bits,   U08,    134,[0:0],   "Off",      "On"
       CLTdisableBoostControl = bits,   U08,    134,[1:1],   "Off",      "On"
       IATdisableBoostControl = bits,   U08,    134,[2:2],   "Off",      "On"
-      unused15_134_3         = bits,   U08,    134,[3:3],   "Off",      "On"
-      unused15_134_4         = bits,   U08,    134,[4:4],   "Off",      "On"
-      unused15_134_5         = bits,   U08,    134,[5:5],   "Off",      "On"
+      iacPWMfanUp            = bits,   U08,    134,[3:5],   "0", "1", "2", "3", "4", "5", "6", "7"
       unused15_134_6         = bits,   U08,    134,[6:6],   "Off",      "On"
       unused15_134_7         = bits,   U08,    134,[7:7],   "Off",      "On"
       flexBoostLimitAdds     = array,  U08,    135,  [6],   "kPa",       1.0,       0.0,  0.0,     255,    0
@@ -2152,6 +2150,7 @@ menuDialog = main
   iacAlgorithm      = "Selects method of idle control.\nNone = no idle control valve.\nOn/Off valve.\nPWM valve (2,3 wire).\nStepper Valve (4,6,8 wire)."
   iacPWMdir         = "Normal PWM valves increase RPM with higher duty. If RPM decreases with higher duty then select Reverse"
   iacPWMrun         = "Determines if the idle valve runs before engine is cranked over. This can help starting the engine by letting more air in before the RPM sync is achieved."
+  iacPWMfanUp       = "PWM DC% added to base DC% when fan is on."
   iacCLminValue     = "When using closed loop idle control, this is the minimum position value that the PID loop will allow. Combined with the maximum value, this specifies the working range of your idle valve"
   iacCLmaxValue     = "When using closed loop idle control, this is the maximum position value that the PID loop will allow. Combined with the minimum value, this specifies the working range of your idle valve"
   iacTPSlimit       = "When using OL+CL idle control, if the TPS is higher than this value closed loop idle resets the integral of the PID (To prevent RPM dips coming back to idle)"
@@ -2826,6 +2825,8 @@ menuDialog = main
       field = "Idle valve frequency", idleFreq,                 { iacAlgorithm == 2 || iacAlgorithm == 3 || iacAlgorithm == 6 }
       field = "Idle valve direction", iacPWMdir,                { iacAlgorithm == 2 || iacAlgorithm == 3 || iacAlgorithm == 6 }
       field = "Run before start",     iacPWMrun,                { iacAlgorithm == 2 || iacAlgorithm == 3 || iacAlgorithm == 6 }
+      field = "Run before start",     iacPWMrun,                { iacAlgorithm == 2 || iacAlgorithm == 3 || iacAlgorithm == 6 }
+      field = "Fan on DC increase (idle up)",   iacPWMfanUp,              { iacAlgorithm == 2 || iacAlgorithm == 6 }
 
     dialog = closedloop_idle, "Closed loop Idle"
       displayOnlyField = "#                      !!! Please note that 1.0 means 100% !!!"

--- a/speeduino/auxiliaries.ino
+++ b/speeduino/auxiliaries.ino
@@ -646,6 +646,13 @@ byte getBoostTableVal(void)
     currentStatus.flexBoostCorrection = 0;
   }
 
+  BoostTableVal *= 2;
+
+  if (configPage15.boostDCiatAdjEnable == 1 && configPage4.boostType == OPEN_LOOP_BOOST)
+  {
+    BoostTableVal += table2D_getValue(&boostIATadjTable, currentStatus.IAT + CALIBRATION_TEMPERATURE_OFFSET);
+  }
+
   if (checkBoostControlProt())
   {
     BoostTableVal = 0;
@@ -669,7 +676,7 @@ void boostControl(void)
 
       else
       { 
-        currentStatus.boostDuty = getBoostTableVal() * 2 * 100; 
+        currentStatus.boostDuty = getBoostTableVal() * 100; 
       }
 
       if(currentStatus.boostDuty > 10000) 
@@ -720,7 +727,12 @@ void boostControl(void)
             else { boostPID.SetTunings(configPage6.boostKP, configPage6.boostKI, configPage6.boostKD); }
           }
 
-          byte boostTableLookupDutyVal = get3DTableValue(&boostTableLookupDuty, currentStatus.boostTarget, currentStatus.RPM) * 100 / 2;
+          uint16_t boostTableLookupDutyVal = get3DTableValue(&boostTableLookupDuty, currentStatus.boostTarget, currentStatus.RPM) * 100 / 2;
+          if (configPage15.boostDCiatAdjEnable)
+          {
+            boostTableLookupDutyVal += table2D_getValue(&boostIATadjTable, currentStatus.IAT + CALIBRATION_TEMPERATURE_OFFSET) * 100;
+          }
+          
           bool PIDcomputed = boostPID.Compute(boostTableLookupDutyVal); //Compute() returns false if the required interval has not yet passed.
           int16_t minBoostDuty = boostTableLookupDutyVal - (configPage15.boostAuthMinus * 100); 
           if (minBoostDuty < 0) {minBoostDuty = 0;} 

--- a/speeduino/auxiliaries.ino
+++ b/speeduino/auxiliaries.ino
@@ -720,7 +720,22 @@ void boostControl(void)
             else { boostPID.SetTunings(configPage6.boostKP, configPage6.boostKI, configPage6.boostKD); }
           }
 
-          bool PIDcomputed = boostPID.Compute(get3DTableValue(&boostTableLookupDuty, currentStatus.boostTarget, currentStatus.RPM) * 100/2); //Compute() returns false if the required interval has not yet passed.
+          byte boostTableLookupDutyVal = get3DTableValue(&boostTableLookupDuty, currentStatus.boostTarget, currentStatus.RPM) * 100 / 2;
+          bool PIDcomputed = boostPID.Compute(boostTableLookupDutyVal); //Compute() returns false if the required interval has not yet passed.
+          int16_t minBoostDuty = boostTableLookupDutyVal - (configPage15.boostAuthMinus * 100); 
+          if (minBoostDuty < 0) {minBoostDuty = 0;} 
+
+          if (currentStatus.boostDuty > uint16_t(boostTableLookupDutyVal + (configPage15.boostAuthPlus * 100)))
+          {
+            currentStatus.boostDuty = boostTableLookupDutyVal + (configPage15.boostAuthPlus * 100);
+          }
+
+          else if (currentStatus.boostDuty < uint16_t(minBoostDuty))
+          {
+            currentStatus.boostDuty = minBoostDuty;
+          }
+
+
           if(currentStatus.boostDuty == 0) { DISABLE_BOOST_TIMER(); BOOST_PIN_LOW(); } //If boost duty is 0, shut everything down
           else
           {

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1521,8 +1521,8 @@ struct config15 {
   byte boostAuthPlus;
   byte boostAuthMinus;
 
-  //Bytes 148-206
-  byte Unused15_158_175[20];
+  //Bytes 158-175
+  byte Unused15_158_175[18];
 
   //*Boost table 2 occupies bytes 176-255*
   

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1518,8 +1518,11 @@ struct config15 {
   byte iacCorrectionBins[4];
   int8_t iacBattCorrectionValues[4];
 
+  byte boostAuthPlus;
+  byte boostAuthMinus;
+
   //Bytes 148-206
-  byte Unused15_156_175[20];
+  byte Unused15_158_175[20];
 
   //*Boost table 2 occupies bytes 176-255*
   

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -519,6 +519,7 @@ extern struct table2D wmiAdvTable; //6 bin wmi correction table for timing advan
 extern struct table2D coolantProtectTable; //6 bin coolant temperature protection table for engine protection (2D)
 extern struct table2D fanPWMTable;
 extern struct table2D rollingCutTable;
+extern struct table2D boostIATadjTable;
 
 //These are for the direct port manipulation of the injectors, coils and aux outputs
 extern volatile PORT_TYPE *inj1_pin_port;
@@ -1494,7 +1495,7 @@ struct config15 {
   byte rollingProtCutPercent[4];
   
   //Secondary corrections tables
-  //Bytes 106-127
+  //Bytes 106-165
   byte asePct2[4];           ///< Afterstart enrichment values 2 (%)
   byte wueValues2[10];   ///< Warm up enrichment array 2 (10 bytes, transferred to @ref WUETable2
   byte crankingEnrichValues2[4];
@@ -1504,7 +1505,7 @@ struct config15 {
   byte CLTdisableBoostControl : 1;
   byte IATdisableBoostControl : 1;
   byte iacPWMfanUp : 3;
-  byte unused15_134_6 : 1;
+  byte boostDCiatAdjEnable : 1;
   byte unused15_134_7 : 1;
 
   byte flexBoostLimitAdds[6];
@@ -1521,8 +1522,11 @@ struct config15 {
   byte boostAuthPlus;
   byte boostAuthMinus;
 
-  //Bytes 158-175
-  byte Unused15_158_175[18];
+  int8_t boostDCiatAdj[4];
+  byte   boostDCiatBins[4];
+
+  //Bytes 166-175
+  byte Unused15_166_175[10];
 
   //*Boost table 2 occupies bytes 176-255*
   

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1517,8 +1517,11 @@ struct config15 {
   byte taeValues2[4];  ///< TPS based acceleration enrichment rates 2 (Unit: % to add), values matched to thresholds of taeBins
   byte aeColdPct2;  //AE cold clt modifier % no. 2. To be used with flex fuel
 
+  byte iacCorrectionBins[4];
+  int8_t iacBattCorrectionValues[4];
+
   //Bytes 148-206
-  byte Unused15_148_175[28];
+  byte Unused15_156_175[20];
 
   //*Boost table 2 occupies bytes 176-255*
   

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -1503,9 +1503,7 @@ struct config15 {
   byte CLTBoostCutEnabled : 1;
   byte CLTdisableBoostControl : 1;
   byte IATdisableBoostControl : 1;
-  byte unused15_134_3 : 1;
-  byte unused15_134_4 : 1;
-  byte unused15_134_5 : 1;
+  byte iacPWMfanUp : 3;
   byte unused15_134_6 : 1;
   byte unused15_134_7 : 1;
 

--- a/speeduino/globals.ino
+++ b/speeduino/globals.ino
@@ -63,6 +63,7 @@ struct table2D wmiAdvTable; //6 bin wmi correction table for timing advance (2D)
 struct table2D coolantProtectTable;
 struct table2D fanPWMTable;
 struct table2D rollingCutTable;
+struct table2D boostIATadjTable;
 
 /// volatile inj*_pin_port and  inj*_pin_mask vars are for the direct port manipulation of the injectors, coils and aux outputs.
 volatile PORT_TYPE *inj1_pin_port;

--- a/speeduino/idle.h
+++ b/speeduino/idle.h
@@ -37,6 +37,7 @@ struct StepperIdle
 };
 
 struct table2D iacPWMTable;
+struct table2D iacPWMBattCorrTable;
 struct table2D iacStepTable;
 //Open loop tables specifically for cranking
 struct table2D iacCrankStepsTable;

--- a/speeduino/idle.ino
+++ b/speeduino/idle.ino
@@ -67,6 +67,12 @@ void initialiseIdle(bool forcehoming)
       iacPWMTable.values = configPage6.iacOLPWMVal;
       iacPWMTable.axisX = configPage6.iacBins;
 
+      iacPWMBattCorrTable.xSize = 4;
+      iacPWMBattCorrTable.valueSize = SIZE_SIGNED_BYTE;
+      iacPWMBattCorrTable.axisSize = SIZE_BYTE;
+      iacPWMBattCorrTable.values = configPage15.iacBattCorrectionValues;
+      iacPWMBattCorrTable.axisX = configPage15.iacCorrectionBins;
+
 
       iacCrankDutyTable.xSize = 4;
       iacCrankDutyTable.valueSize = SIZE_BYTE;
@@ -91,6 +97,12 @@ void initialiseIdle(bool forcehoming)
       iacPWMTable.axisSize = SIZE_BYTE;
       iacPWMTable.values = configPage6.iacOLPWMVal;
       iacPWMTable.axisX = configPage6.iacBins;
+
+      iacPWMBattCorrTable.xSize = 4;
+      iacPWMBattCorrTable.valueSize = SIZE_SIGNED_BYTE;
+      iacPWMBattCorrTable.axisSize = SIZE_BYTE;
+      iacPWMBattCorrTable.values = configPage15.iacBattCorrectionValues;
+      iacPWMBattCorrTable.axisX = configPage15.iacCorrectionBins;
 
       iacCrankDutyTable.xSize = 4;
       iacCrankDutyTable.valueSize = SIZE_BYTE;
@@ -476,6 +488,7 @@ void idleControl(void)
         {
           //Standard running
           currentStatus.idleLoad = table2D_getValue(&iacPWMTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET); //All temps are offset by 40 degrees
+          currentStatus.idleLoad += table2D_getValue(&iacPWMBattCorrTable, currentStatus.battery10);
         }
         // Add air conditioning idle-up - we only do this if the engine is running (A/C should never engage with engine off).
         if(configPage15.airConIdleSteps>0 && BIT_CHECK(currentStatus.airConStatus, BIT_AIRCON_TURNING_ON) == true) { currentStatus.idleLoad += configPage15.airConIdleSteps; }
@@ -602,6 +615,7 @@ void idleControl(void)
         {
           idle_pwm_target_value = idle_pid_target_value>>2; //increased resolution
           currentStatus.idleLoad = ((unsigned long)(idle_pwm_target_value * 100UL) / idle_pwm_max_count);
+          currentStatus.idleLoad += table2D_getValue(&iacPWMBattCorrTable, currentStatus.battery10);
         }
         idleCounter++;
       }

--- a/speeduino/init.ino
+++ b/speeduino/init.ino
@@ -288,7 +288,6 @@ void initialiseAll(void)
     coolantProtectTable.values = configPage9.coolantProtRPM;
     coolantProtectTable.axisX = configPage9.coolantProtTemp;
 
-
     fanPWMTable.valueSize = SIZE_BYTE;
     fanPWMTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins
     fanPWMTable.xSize = 4;
@@ -300,6 +299,12 @@ void initialiseAll(void)
     rollingCutTable.xSize = 4;
     rollingCutTable.values = configPage15.rollingProtCutPercent;
     rollingCutTable.axisX = configPage15.rollingProtRPMDelta;
+
+    boostIATadjTable.valueSize = SIZE_SIGNED_BYTE;
+    boostIATadjTable.axisSize = SIZE_BYTE;
+    boostIATadjTable.xSize = 4;
+    boostIATadjTable.values = configPage15.boostDCiatAdj;
+    boostIATadjTable.axisX = configPage15.boostDCiatBins;
 
     wmiAdvTable.valueSize = SIZE_BYTE;
     wmiAdvTable.axisSize = SIZE_BYTE; //Set this table to use byte axis bins


### PR DESCRIPTION
Added several features:

- Idle PWM Battery correction

Should help to combat idle droop from accessories such as headlights, blower motor, etc. turning on

- Radiator Fan Idle Up

Can now raise IACV duty cycle when radiator fan is on

- Closed loop boost control max auth (+/-)

Can now limit how much closed loop boost control PID algorithm is allowed to stray from base duty cycle. Separate values for + and -. Should help to combat overshoot of boost target.

- Boost Duty Cycle vs. IAT table

Add and subtract from open loop duty cycle and closed loop base duty cycle based on intake air temperature.